### PR TITLE
Upgrade leanengine to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cookie-session": "^2.0.0-alpha.1",
     "ejs": "2.3.1",
     "express": "4.12.3",
-    "leanengine": "^0.2.0",
+    "leanengine": "^0.4.0",
     "leanengine-sniper": "^0.3.2",
     "redis": "^2.3.0",
     "request": "^2.65.0",


### PR DESCRIPTION
JS SDK 的自动测试需要 https://github.com/leancloud/leanengine-node-sdk/pull/49
